### PR TITLE
setup.py: lower py version support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+regex >= 2023.0.0
+# Development dependencies (optional)
+pytest >= 7.0
+twine >= 4.0.2

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import find_packages, setup 
+from setuptools import find_packages, setup
 import os
 
 with open(os.path.join(os.path.dirname(__file__),'README.md'), "r", encoding = "utf-8") as f:
@@ -28,5 +28,5 @@ setup(
     extras_require={
         "dev": ["pytest>=7.0", "twine>=4.0.2"],
     },
-    python_requires=">=3.11"
+    python_requires=">=3.8"
 )


### PR DESCRIPTION
I do not believe you mean to limit the min Py version but if you do please close this PR. I need to do this before I move forward with other PRs kake @aso-mehmudi.
